### PR TITLE
Adicionar parametro permitindo realizar a busca através de um proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ OBS: é importante inserir os dados de login corretamente, caso estejam incorret
 a listagem de anúncios mas não conseguirá notificar por email. Também é interessante deixar o argumento -t com valor 60
 pois a listagem da olx só atualiza a cada 1 minuto, valores menores que 60 segundos pode causar mau comportamento do script.
 
+## Proxy
+Caso necessite realizar a requisção através de um proxy, o parametro -p recebe uma string com a configuração de proxy, seja com autenticação
+ou não. Exemplo:
+```
+-p http://ip:porta
+```
+Ou ainda:
+```
+-p http://usuario:senha@ip:porta
+```
 
 ## Autor
 

--- a/olxcrapper/olxcrapper.py
+++ b/olxcrapper/olxcrapper.py
@@ -32,6 +32,7 @@ def main():
     parser.add_argument('-g', '--gmail', type=str, metavar='', required=True, help='Endereço do GMail')
     parser.add_argument('-s', '--senha', type=str, metavar='', required=True, help='Senha do GMail')
     parser.add_argument('-t', '--timesleep', type=int, metavar='', required=True, help='Tempo entre atualizações de lista (em segundos)')
+    parser.add_argument('-p', '--proxy', type=str, metavar='', required=False, help='Utilizar proxy para realizar as requisições')
 
     args = parser.parse_args()
 
@@ -39,6 +40,10 @@ def main():
     EMAIL_ADDRESS = args.gmail
     EMAIL_PASSWORD = args.senha
     timesleep = args.timesleep
+    proxy = args.proxy
+    
+    if proxy is not None:
+    	proxies = {"http": proxy, "https": proxy}
 
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36'}
 
@@ -67,15 +72,21 @@ def main():
 
 
     def statuscode(URL=URL, headers=headers):
+        if proxies is None:
+        	result = requests.get(URL, headers=headers)
+        else:
+        	result = requests.get(URL, headers=headers, proxies=proxies)
 
-        result = requests.get(URL, headers=headers)
         statuscodenumber = int(result.status_code)
 
         return(statuscodenumber)
 
     def webscrap(URL=URL, headers=headers):
+        if proxies is None:
+        	result = requests.get(URL, headers=headers)
+        else:
+        	result = requests.get(URL, headers=headers, proxies=proxies)
 
-        result = requests.get(URL, headers=headers)
         src = result.content
         soup = BeautifulSoup(src, 'lxml') # Usando o parser do BS4, alternativamente usar: (src, 'lxml')
         items = soup.find_all('a')

--- a/olxcrapper/olxcrapper.py
+++ b/olxcrapper/olxcrapper.py
@@ -72,7 +72,7 @@ def main():
 
 
     def statuscode(URL=URL, headers=headers):
-        if proxies is None:
+        if proxy is None:
         	result = requests.get(URL, headers=headers)
         else:
         	result = requests.get(URL, headers=headers, proxies=proxies)
@@ -82,7 +82,7 @@ def main():
         return(statuscodenumber)
 
     def webscrap(URL=URL, headers=headers):
-        if proxies is None:
+        if proxy is None:
         	result = requests.get(URL, headers=headers)
         else:
         	result = requests.get(URL, headers=headers, proxies=proxies)

--- a/olxcrapper/olxcrapper.py
+++ b/olxcrapper/olxcrapper.py
@@ -43,7 +43,7 @@ def main():
     proxy = args.proxy
     
     if proxy is not None:
-    	proxies = {"http": proxy, "https": proxy}
+        proxies = {"http": proxy, "https": proxy}
 
     headers = {'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36'}
 
@@ -72,21 +72,13 @@ def main():
 
 
     def statuscode(URL=URL, headers=headers):
-        if proxy is None:
-        	result = requests.get(URL, headers=headers)
-        else:
-        	result = requests.get(URL, headers=headers, proxies=proxies)
-
+        result = makeRequest()
         statuscodenumber = int(result.status_code)
 
         return(statuscodenumber)
 
     def webscrap(URL=URL, headers=headers):
-        if proxy is None:
-        	result = requests.get(URL, headers=headers)
-        else:
-        	result = requests.get(URL, headers=headers, proxies=proxies)
-
+        result = makeRequest()
         src = result.content
         soup = BeautifulSoup(src, 'lxml') # Usando o parser do BS4, alternativamente usar: (src, 'lxml')
         items = soup.find_all('a')
@@ -106,6 +98,14 @@ def main():
         print("\n-------------------------------------------------------------------------------------------------")
 
         return(lista)
+
+    def makeRequest(URL=URL, headers=headers, proxy=proxy):
+        if proxy is None:
+            result = requests.get(URL, headers=headers)
+        else:
+            result = requests.get(URL, headers=headers, proxies=proxies)
+
+        return(result)
 
     # EXECUÇÃO DO SCRIPT:
 
@@ -148,4 +148,4 @@ def main():
         time.sleep(timesleep)
 
 if __name__ == "__main__":
-	main()
+    main()

--- a/olxcrapper/olxcrapper.py
+++ b/olxcrapper/olxcrapper.py
@@ -71,13 +71,13 @@ def main():
             _ = os.system('cls')
 
 
-    def statuscode(URL=URL, headers=headers):
+    def statuscode():
         result = makeRequest()
         statuscodenumber = int(result.status_code)
 
         return(statuscodenumber)
 
-    def webscrap(URL=URL, headers=headers):
+    def webscrap():
         result = makeRequest()
         src = result.content
         soup = BeautifulSoup(src, 'lxml') # Usando o parser do BS4, alternativamente usar: (src, 'lxml')
@@ -99,7 +99,7 @@ def main():
 
         return(lista)
 
-    def makeRequest(URL=URL, headers=headers, proxy=proxy):
+    def makeRequest(URL=URL, headers=headers):
         if proxy is None:
             result = requests.get(URL, headers=headers)
         else:


### PR DESCRIPTION
O projeto não realizava os requests quando o usuário estava conectado através de um proxy (local, remoto, da empresa que trabalha, etc).

Adiconado parametro que permite passar a url do proxy para realizar os requests.